### PR TITLE
Feature/locale currency support

### DIFF
--- a/landing-page/script.js
+++ b/landing-page/script.js
@@ -1,6 +1,61 @@
 // ===== Config =====
 const API_URL = 'https://a5692388-7de2-4b0a-a5ac-eb6998583c8b-00-2cugbbxqp58qp.pike.replit.dev:3000';
 
+// ===== Locale currency detection =====
+const TIMEZONE_CURRENCY_MAP = {
+  'Asia/Bangkok': 'thb',
+  'Asia/Ho_Chi_Minh': 'vnd',
+  'Asia/Saigon': 'vnd',
+  'Asia/Singapore': 'sgd',
+  'Asia/Kuala_Lumpur': 'myr',
+  'Asia/Manila': 'php',
+  'Asia/Jakarta': 'idr',
+  'Asia/Tokyo': 'jpy',
+  'Asia/Seoul': 'krw',
+  'Europe/London': 'gbp',
+  'Europe/Paris': 'eur',
+  'Europe/Berlin': 'eur',
+  'Europe/Amsterdam': 'eur',
+  'Europe/Rome': 'eur',
+  'Europe/Madrid': 'eur',
+  'Europe/Brussels': 'eur',
+  'Europe/Vienna': 'eur',
+  'Europe/Dublin': 'eur',
+  'Europe/Helsinki': 'eur',
+  'Europe/Lisbon': 'eur',
+};
+
+function detectCurrency() {
+  try {
+    const tz = Intl.DateTimeFormat().resolvedOptions().timeZone;
+    return TIMEZONE_CURRENCY_MAP[tz] || 'usd';
+  } catch {
+    return 'usd';
+  }
+}
+
+let detectedCurrency = detectCurrency();
+
+async function loadLocalPricing() {
+  try {
+    const res = await fetch(`${API_URL}/pricing?currency=${detectedCurrency}`);
+    const data = await res.json();
+    detectedCurrency = data.currency;
+
+    document.querySelectorAll('.product__price').forEach(el => {
+      el.textContent = data.display;
+    });
+
+    document.querySelectorAll('[data-checkout]').forEach(btn => {
+      btn.textContent = `Get the Playbook — ${data.display}`;
+    });
+  } catch (err) {
+    console.error('Failed to load local pricing:', err);
+  }
+}
+
+loadLocalPricing();
+
 // ===== Scroll animations =====
 const observer = new IntersectionObserver((entries) => {
   entries.forEach(e => {
@@ -33,6 +88,7 @@ document.querySelectorAll('a[href^="#"]').forEach(a => {
 document.querySelectorAll('[data-checkout]').forEach(btn => {
   btn.addEventListener('click', async (e) => {
     e.preventDefault();
+    const originalText = btn.textContent;
     btn.textContent = 'Redirecting…';
     btn.style.pointerEvents = 'none';
 
@@ -40,6 +96,7 @@ document.querySelectorAll('[data-checkout]').forEach(btn => {
       const res = await fetch(`${API_URL}/create-checkout-session/playbook`, {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ currency: detectedCurrency }),
       });
       const data = await res.json();
 
@@ -51,7 +108,7 @@ document.querySelectorAll('[data-checkout]').forEach(btn => {
     } catch (err) {
       console.error('Checkout error:', err);
       alert('Something went wrong. Please try again.');
-      btn.textContent = 'Get the Playbook — $29';
+      btn.textContent = originalText;
       btn.style.pointerEvents = '';
     }
   });

--- a/replit.md
+++ b/replit.md
@@ -45,12 +45,20 @@ Managed via Replit Secrets and Environment Variables:
 
 ## API Endpoints
 
-- `POST /create-checkout-session/playbook` — Creates a Stripe checkout session for The Quiet Operator Playbook ($29)
+- `POST /create-checkout-session/playbook` — Creates a Stripe checkout session. Accepts optional `{ currency: "thb" }` body for local currency pricing
+- `GET /pricing?currency=thb` — Returns pricing info for a given currency (amount, symbol, display string, supported currencies)
 - `GET /health` — Health check
 
 ## Products
 
-- **The Quiet Operator Playbook**: $29
+- **The Quiet Operator Playbook**: $29 USD (with locale currency support)
+
+## Locale Currency Support
+
+The frontend detects the user's timezone and maps it to a local currency. Supported currencies:
+- USD ($29), THB (฿999), VND (₫749,000), SGD (S$39), MYR (RM129), PHP (₱1,599), IDR (Rp469,000), JPY (¥4,500), KRW (₩39,000), EUR (€27), GBP (£23)
+- Prices are fixed per currency (not live exchange rates) and defined in server/server.js PRICING map
+- Falls back to USD for unsupported timezones/currencies
 
 ## Setup Notes
 

--- a/server/server.js
+++ b/server/server.js
@@ -19,22 +19,51 @@ app.use(express.json());
 const PRODUCT = {
   name: 'The Quiet Operator Playbook',
   description: 'The step-by-step playbook for turning AI skills into recurring revenue.',
-  price: 2900, // $29.00 in cents
 };
 
+const PRICING = {
+  usd: { amount: 2900, symbol: '$', display: '$29' },
+  thb: { amount: 99900, symbol: '฿', display: '฿999' },
+  vnd: { amount: 74900000, symbol: '₫', display: '₫749,000' },
+  sgd: { amount: 3900, symbol: 'S$', display: 'S$39' },
+  myr: { amount: 12900, symbol: 'RM', display: 'RM129' },
+  php: { amount: 159900, symbol: '₱', display: '₱1,599' },
+  idr: { amount: 46900000, symbol: 'Rp', display: 'Rp469,000' },
+  jpy: { amount: 4500, symbol: '¥', display: '¥4,500' },
+  krw: { amount: 3900000, symbol: '₩', display: '₩39,000' },
+  eur: { amount: 2700, symbol: '€', display: '€27' },
+  gbp: { amount: 2300, symbol: '£', display: '£23' },
+};
+
+app.get('/pricing', (req, res) => {
+  const currency = (req.query.currency || 'usd').toLowerCase();
+  const pricing = PRICING[currency] || PRICING.usd;
+  res.json({
+    currency: PRICING[currency] ? currency : 'usd',
+    amount: pricing.amount,
+    symbol: pricing.symbol,
+    display: pricing.display,
+    supported: Object.keys(PRICING),
+  });
+});
+
 app.post('/create-checkout-session/playbook', async (req, res) => {
+  const requestedCurrency = (req.body.currency || 'usd').toLowerCase();
+  const currency = PRICING[requestedCurrency] ? requestedCurrency : 'usd';
+  const pricing = PRICING[currency];
+
   try {
     const session = await stripe.checkout.sessions.create({
       payment_method_types: ['card'],
       line_items: [
         {
           price_data: {
-            currency: 'usd',
+            currency: currency,
             product_data: {
               name: PRODUCT.name,
               description: PRODUCT.description,
             },
-            unit_amount: PRODUCT.price,
+            unit_amount: pricing.amount,
           },
           quantity: 1,
         },


### PR DESCRIPTION
This pull request adds locale-based currency support for pricing and checkout on the landing page, allowing users to see prices and pay in their local currency based on their timezone. The frontend detects the user's timezone, maps it to a supported currency, fetches the correct price from the backend, and sends the selected currency when creating a checkout session. The backend now supports multiple currencies for the playbook product and exposes new endpoints for pricing info.

**Locale currency support and pricing logic:**

* Added a timezone-to-currency mapping and detection logic in `landing-page/script.js` to automatically set the user's currency and update displayed prices accordingly.
* Implemented a new `/pricing` endpoint in `server/server.js` that returns price info for a requested currency, and a currency-aware `/create-checkout-session/playbook` endpoint to create Stripe checkout sessions in the user's local currency.

**Frontend integration and UX improvements:**

* Updated checkout button logic to send the detected currency to the backend, and improved error handling to restore the original button text on failure. [[1]](diffhunk://#diff-1267943028d877dd08636ef09dceb3e736fb6b9b91d60135376fcf8ca273b57dR91-R99) [[2]](diffhunk://#diff-1267943028d877dd08636ef09dceb3e736fb6b9b91d60135376fcf8ca273b57dL54-R111)
* The checkout button and displayed prices now reflect the user's local currency, improving clarity and reducing friction for international users.

**Documentation updates:**

* Updated `replit.md` to describe new endpoints, the playbook product, and how locale currency support works, including a list of supported currencies and fallback behavior.